### PR TITLE
Set the HR buffers up before shaping with a plan

### DIFF
--- a/diffenator3-lib/src/render/renderer.rs
+++ b/diffenator3-lib/src/render/renderer.rs
@@ -94,6 +94,13 @@ impl<'a> Renderer<'a> {
 
         let output = if let Some(plan) = &self.plan {
             // If we have a shaping plan, we can use it to shape the string
+            if let Some(script) = plan.script() {
+                buffer.set_script(script);
+            } 
+            buffer.set_direction(plan.direction());
+            if let Some(lang) = plan.language() {
+                buffer.set_language(lang.clone());
+            }
             shaper.shape_with_plan(plan, buffer, &[])
         } else {
             // Otherwise, we guess segment properties


### PR DESCRIPTION
HarfRust demands that you set up the buffers if you shape with a plan. @hoolean and @RickyDaMa helped me write this.

This relies on https://github.com/harfbuzz/harfrust/pull/193.