### PR TITLE
Change 'Old/New' to 'Before/After'

### DIFF
--- a/diffenator3-web/www/index.html
+++ b/diffenator3-web/www/index.html
@@ -117,8 +117,8 @@
 
     <div class="container">
       <div id="ui-nav">
-        <div class="ui-nav-item" id="fonttoggle">Old</div>
-        <div class="ui-nav-item" id="fontanimate">Animate</div>
+        <div class="ui-nav-item" id="fonttoggle">Before</div>
+        <div class="ui-nav-item" id="fontanimate">Animate!</div>
         <div id="axes"></div>
       </div>
 

--- a/diffenator3-web/www/ts/shared.ts
+++ b/diffenator3-web/www/ts/shared.ts
@@ -182,7 +182,7 @@ function diffLanguages(report: Record<string, LanguageDiff>) {
     return;
   }
   $("#difflanguages").append(
-    `<table class="table table-striped" id="difflanguages"><tr><th>Language</th><th>Old</th><th>New</th></tr></table>`
+    `<table class="table table-striped" id="difflanguages"><tr><th>Language</th><th>Before</th><th>After</th></tr></table>`
   );
   for (let [name, diff] of notSame) {
     let row = $("<tr>");
@@ -356,7 +356,7 @@ function diffKerns(report: Report) {
     `<h3 class="border-top pt-2 border-dark-subtle">Modified Kerns</h3>`
   );
   $("#diffkerns").append(
-    `<table class="table table-striped" id="diffkerns"><tr><th>Pair</th><th>Old</th><th>New</th></tr></table>`
+    `<table class="table table-striped" id="diffkerns"><tr><th>Pair</th><th>Before</th><th>After</th></tr></table>`
   );
   for (let [pair, value] of Object.entries(report["kerns"])) {
     if (pair == "error") {
@@ -444,7 +444,7 @@ function cmapDiff(cmap_diff: CmapDiff | undefined) {
   );
   if (cmap_diff && (cmap_diff.new || cmap_diff.missing)) {
     if (cmap_diff.new) {
-      $("#cmapdiff").append(`<h4>Added Glyphs</h4>`);
+      $("#cmapdiff").append(`<h4>Added Glyphs</h4><p>Be sure to look at the 'after' because the 'before' will likely show tofu</p>`);
       let added = $("<div>");
       for (let glyph of cmap_diff.new) {
         addAGlyph(glyph, added);
@@ -467,11 +467,11 @@ function cmapDiff(cmap_diff: CmapDiff | undefined) {
 
 function setupAnimation() {
   $("#fonttoggle").click(function () {
-    if ($(this).text() == "Old") {
-      $(this).text("New");
+    if ($(this).text() == "Before") {
+      $(this).text("After");
       $(".font-before").removeClass("font-before").addClass("font-after");
     } else {
-      $(this).text("Old");
+      $(this).text("Before");
       $(".font-after").removeClass("font-after").addClass("font-before");
     }
   });


### PR DESCRIPTION
It was bugging me that the `#fonttoggle` switch used a different name than the loading screen. 

It might also be ideal to color code that switch red/green to match, but I didn't make the effort to do this

I may have missed places too. 